### PR TITLE
Added a new feature to display next leaderboard position details

### DIFF
--- a/index.js
+++ b/index.js
@@ -452,7 +452,7 @@ client.on("guildMemberAdd", async member => {
 		const guildRT = reactionTimes[m.guild.id];
 		const answertime = new Date();
 		const deltatime = answertime - jointime;
-		let dtstring = deltatime + 'ms';
+		let dtstring = `${deltatime > 1000 ? (deltatime % 60000 / 1000).toFixed(rstDecimal)+'s' : deltatime+'ms'}`;
 		console.log(`[WP][${m.guild.name}(${m.guild.id})] ${m.author.username} was the first to welcome ${member.user.username}! They scored a welcome point!`);
 		if (guildPoints[m.author.id] === undefined || guildPoints[m.author.id] == 0){
 			points[m.guild.id][m.author.id] = 1;

--- a/index.js
+++ b/index.js
@@ -9,7 +9,8 @@ const points = require('./points.json');
 const reactionTimes = require('./reactionTimes.json')
 const fs = require('fs');
 const prefix = config.prefix;
-const rstDecimal = 2;
+const rstDecimal = 2; // Response time accuracy
+
 client.once('ready', () => {
     console.log('[INIT] Ready!');
 });
@@ -273,7 +274,7 @@ client.on('message', async message => {
 			if (sortedLB.findIndex(entry => entry[0] == whocalls.id) != -1) {
 				posstr = `${getPlacementString(sortedLB.findIndex(entry => entry[0] == whocalls.id)+1)} place`;
 
-				// Determine who is one place above the requested user on the leaderboard
+				// Determine who is one place above the requested user on the WP leaderboard
 				// and how many points are needed to take their place
 				nextPos = sortedLB.findIndex(entry => entry[0] == whocalls.id);
 				if (nextPos != 0 && typeof nextPos != 'undefined') {
@@ -288,6 +289,8 @@ client.on('message', async message => {
 			let rtstr = 'No reaction time registered';
 			if (guildRT[whocalls.id]) {
 				rtstr = `${guildRT[whocalls.id] > 1000 ? (guildRT[whocalls.id] % 60000 / 1000).toFixed(rstDecimal)+'s' : guildRT[whocalls.id]+'ms'}`;
+				// Determine who is one place above the requested user on the RT leaderboard
+				// and how much faster they need to be to take their place
                 nextRstPos = sortedRT.findIndex(entry => entry[0] == whocalls.id);
                 if (nextRstPos != 0 && typeof nextRstPos != 'undefined') {
 				    rstPosStr = `${getPlacementString(nextRstPos).replace('🔸', '')} place`;
@@ -325,7 +328,7 @@ client.on('message', async message => {
 			if (sortedLB.findIndex(entry => entry[0] == who.id) != -1) {
 				posstr = `${getPlacementString(sortedLB.findIndex(entry => entry[0] == who.id)+1)} place`;
 
-				// Determine who is one place above the requested user on the leaderboard
+				// Determine who is one place above the requested user on the WP leaderboard
 				// and how many points are needed to take their place
 				nextPos = sortedLB.findIndex(entry => entry[0] == who.id);
 				if (nextPos != 0 && typeof nextPos != 'undefined') {
@@ -340,6 +343,8 @@ client.on('message', async message => {
 			let rtstr = 'No reaction time registered';
 			if (guildRT[who.id]) { 
 				rtstr = `${guildRT[who.id] > 1000 ? (guildRT[who.id] % 60000 / 1000).toFixed(rstDecimal)+'s' : guildRT[who.id]+'ms'}`;
+				// Determine who is one place above the requested user on the RT leaderboard
+				// and how much faster they need to be to take their place
                 nextRstPos = sortedRT.findIndex(entry => entry[0] == who.id);
                 if (nextRstPos != 0 && typeof nextRstPos != 'undefined') {
 				    rstPosStr = `${getPlacementString(nextRstPos).replace('🔸', '')} place`;
@@ -381,7 +386,7 @@ client.on('message', async message => {
 				let nextPosUser = 'unknown [not in server]';
 				let nextPos, nextPosPoints, pointsNeeded = 0;
 
-				// Determine who is one place above the requested user on the leaderboard
+				// Determine who is one place above the requested user on the WP leaderboard
 				// and how many points are needed to take their place
 				nextPos = sortedLB.findIndex(entry => entry[0] == whois.id);
 				if (nextPos != 0 && typeof nextPos != 'undefined') {
@@ -395,6 +400,8 @@ client.on('message', async message => {
 				let rtstr = 'No reaction time registered';
 				if (guildRT[sortedLB[pos-1][0]]) { 
 					rtstr = `${guildRT[sortedLB[pos-1][0]] > 1000 ? (guildRT[sortedLB[pos-1][0]] % 60000 / 1000).toFixed(rstDecimal)+'s' : guildRT[sortedLB[pos-1][0]]+'ms'}`;
+					// Determine who is one place above the requested user on the RT leaderboard
+					// and how much faster they need to be to take their place
                 	nextRstPos = sortedRT.findIndex(entry => entry[0] == whois.id);
                 	if (nextRstPos != 0 && typeof nextRstPos != 'undefined') {
 					    rstPosStr = `${getPlacementString(nextRstPos).replace('🔸', '')} place`;
@@ -421,11 +428,6 @@ client.on('message', async message => {
 	} else if (command == 'help' || command == 'h'){
 		message.reply(sendHelp(whocalls, guildPrefix));
 	}
-	//if (!message.content.toLowerCase().startsWith('!clear')) { 
-	//	message.delete()
-	//	.then(() => console.log(`${whocalls.username}'s command message has been deleted`))
-	//	.catch(err => console.log(err));
-	//}
 });
 
 /* Welcome Points */

--- a/index.js
+++ b/index.js
@@ -8,11 +8,10 @@ const config = require('./config.json')
 const points = require('./points.json');
 const reactionTimes = require('./reactionTimes.json')
 const fs = require('fs');
-
 const prefix = config.prefix;
-
+const rstDecimal = 2;
 client.once('ready', () => {
-  console.log('[INIT] Ready!');
+    console.log('[INIT] Ready!');
 });
 
 //client.login(process.env.TOKEN); Using .json token while I fix Docker issues.
@@ -199,14 +198,17 @@ client.on('message', async message => {
 			catch(err) { console.error(err); }
 		}
 
-		// sort point db into array []
+		// sort point & response time db into array []
 		const sortedLB = Object.entries(guildPoints)
 			.sort(([,x],[,y]) => y-x);
 
+		const sortedRT = Object.entries(guildRT)
+			.sort(([,x],[,y]) => x-y);
+
 		// base embed
 		const embed = new Discord.MessageEmbed()
-		.setTitle('Welcome Points Leaderboard')
-		.setFooter(`Request by ${whocalls.tag}`, whocalls.displayAvatarURL());
+			.setTitle('Welcome Points Leaderboard')
+			.setFooter(`Request by ${whocalls.tag}`, whocalls.displayAvatarURL());
 
 		// send top25 (or less if not enough entries) if no arguments
 		if (args.length == 0){
@@ -226,7 +228,7 @@ client.on('message', async message => {
 					whoisname = whois.username;
 				} catch (err) {
 				}
-				embed.addField(`${getPlacementString(i+1)} ${whoisname}`, `${sortedLB[i][1]} points`, true);
+				embed.addField(`${getPlacementString(i+1)} ${whoisname}`, `${getPointString(sortedLB[i][1])}`, true);
 			}
 
 			message.reply(embed);
@@ -254,30 +256,58 @@ client.on('message', async message => {
 					whoisname = whois.username;
 				} catch (err) {
 				}
-				embed.addField(`${getPlacementString(i+1)} ${whoisname}`, `${sortedRT[i][1]} ms`, true);
+				embed.addField(`${getPlacementString(i+1)} ${whoisname}`, `${sortedRT[i][1] > 1000 ? (sortedRT[i][1] % 60000 / 1000).toFixed(rstDecimal)+'s' : sortedRT[i][1]+'ms'}`, true);
 			}
 
 			message.reply(embed);
 		} else if (args[0] == 'me') {
 			console.log(`[WP][${message.guild.name}(${message.guild.id})] ${whocalls.username} queried their welcome points info`);
 			let pointsstr = '0 points';
-			if(guildPoints[whocalls.id]) {
-				pointsstr = guildPoints[whocalls.id] + ' points'
+			if (guildPoints[whocalls.id]) {
+				pointsstr = `${getPointString(guildPoints[whocalls.id])}`;
 			}
 
-			let posstr = 'Not on the leaderboard';
+			let posstr, nextposstr = 'Not on the leaderboard';
+			let nextPosUser = 'unknown [not in server]';
+			let nextPos, nextPosPoints, pointsNeeded = 0;
 			if (sortedLB.findIndex(entry => entry[0] == whocalls.id) != -1) {
 				posstr = `${getPlacementString(sortedLB.findIndex(entry => entry[0] == whocalls.id)+1)} place`;
+
+				// Determine who is one place above the requested user on the leaderboard
+				// and how many points are needed to take their place
+				nextPos = sortedLB.findIndex(entry => entry[0] == whocalls.id);
+				if (nextPos != 0 && typeof nextPos != 'undefined') {
+				    nextposstr = `${getPlacementString(nextPos).replace('🔸', '')} place`;
+				    nextPosId = await client.users.fetch(sortedLB[nextPos-1][0]);
+					nextPosUser = nextPosId.username;
+				    nextPosPoints = sortedLB[nextPos-1][1];
+				    pointsNeeded = nextPosPoints - guildPoints[whocalls.id] + 1;
+				}
 			}
 
 			let rtstr = 'No reaction time registered';
-			if (guildRT[whocalls.id]) { 
-				rtstr = guildRT[whocalls.id]+'ms'
+			if (guildRT[whocalls.id]) {
+				rtstr = `${guildRT[whocalls.id] > 1000 ? (guildRT[whocalls.id] % 60000 / 1000).toFixed(rstDecimal)+'s' : guildRT[whocalls.id]+'ms'}`;
+                nextRstPos = sortedRT.findIndex(entry => entry[0] == whocalls.id);
+                if (nextRstPos != 0 && typeof nextRstPos != 'undefined') {
+				    rstPosStr = `${getPlacementString(nextRstPos).replace('🔸', '')} place`;
+				    nextRstPosId = await client.users.fetch(sortedRT[nextRstPos-1][0]);
+					nextRstPosUser = nextRstPosId.username;
+				    nextRstPosMs = sortedRT[nextRstPos-1][1];
+				    timeDifference = guildRT[whocalls.id] - nextRstPosMs + 1;
+				}
 			}
 
 			embed.setDescription(`Your welcome points`)
-			embed.addField(pointsstr,posstr)
-			embed.addField(`Fastest Welcome`,rtstr)
+			embed.addField(pointsstr,posstr, true)
+			if (nextPos != 0 && typeof nextPos != 'undefined') {
+				embed.addField(`Next Position (WP)`, `${nextposstr} held by ${nextPosUser} with ${getPointString(nextPosPoints)}\nYou need ${getPointString(pointsNeeded)} to take their place`, true)
+                embed.addField('\u200B', '\u200B')
+			}
+			embed.addField(`Fastest Welcome`,`${rtstr} - ${getPlacementString(nextRstPos+1).replace('🔸', '') + ' place'}`, true)
+            if (nextRstPos != 0 && typeof nextRstPos != 'undefined') {
+                embed.addField(`Next Position (RT)`, `${rstPosStr} held by ${nextRstPosUser} with ${nextRstPosMs > 1000 ? (nextRstPosMs % 60000 / 1000).toFixed(rstDecimal)+'s' : nextRstPosMs+'ms'}\nYou need to improve by ${timeDifference > 1000 ? (timeDifference % 60000 / 1000).toFixed(rstDecimal)+'s' : timeDifference+'ms'} to take their place`, true)
+            }
 
 			message.reply(embed);
 		} else if (message.mentions.users.size == 1) {
@@ -285,24 +315,51 @@ client.on('message', async message => {
 			console.log(`[WP][${message.guild.name}(${message.guild.id})] ${whocalls.username} queried ${who.username}'s welcome points info`);
 
 			let pointsstr = '0 points';
-			if(guildPoints[who.id]) {
-				pointsstr = guildPoints[who.id] + ' points'
+			if (guildPoints[who.id]) {
+				pointsstr = `${getPointString(guildPoints[who.id])}`;
 			}
 
-			let posstr = 'Not on the leaderboard';
+			let posstr, nextposstr = 'Not on the leaderboard';
+			let nextPosUser = 'unknown [not in server]';
+			let nextPos, nextPosPoints, pointsNeeded = 0;
 			if (sortedLB.findIndex(entry => entry[0] == who.id) != -1) {
 				posstr = `${getPlacementString(sortedLB.findIndex(entry => entry[0] == who.id)+1)} place`;
+
+				// Determine who is one place above the requested user on the leaderboard
+				// and how many points are needed to take their place
+				nextPos = sortedLB.findIndex(entry => entry[0] == who.id);
+				if (nextPos != 0 && typeof nextPos != 'undefined') {
+				    nextposstr = `${getPlacementString(nextPos).replace('🔸', '')} place`;
+				    nextPosId = await client.users.fetch(sortedLB[nextPos-1][0]);
+					nextPosUser = nextPosId.username;
+				    nextPosPoints = sortedLB[nextPos-1][1];
+				    pointsNeeded = nextPosPoints - guildPoints[who.id] + 1;
+				}
 			}
 
 			let rtstr = 'No reaction time registered';
 			if (guildRT[who.id]) { 
-				rtstr = guildRT[who.id]+'ms'
+				rtstr = `${guildRT[who.id] > 1000 ? (guildRT[who.id] % 60000 / 1000).toFixed(rstDecimal)+'s' : guildRT[who.id]+'ms'}`;
+                nextRstPos = sortedRT.findIndex(entry => entry[0] == who.id);
+                if (nextRstPos != 0 && typeof nextRstPos != 'undefined') {
+				    rstPosStr = `${getPlacementString(nextRstPos).replace('🔸', '')} place`;
+				    nextRstPosId = await client.users.fetch(sortedRT[nextRstPos-1][0]);
+					nextRstPosUser = nextRstPosId.username;
+				    nextRstPosMs = sortedRT[nextRstPos-1][1];
+				    timeDifference = guildRT[who.id] - nextRstPosMs + 1;
+				}
 			}
 
 			embed.setDescription(`${who.username}'s welcome points`)
-			embed.addField(pointsstr,posstr)
-			embed.addField(`Fastest Welcome`,rtstr)
-
+			embed.addField(pointsstr,posstr, true)
+			if (nextPos != 0 && typeof nextPos != 'undefined') {
+				embed.addField(`Next Position (WP)`, `${nextposstr} held by ${nextPosUser} with ${getPointString(nextPosPoints)}\n${who.username} needs ${getPointString(pointsNeeded)} to take their place`, true)
+				embed.addField('\u200B', '\u200B')
+			}
+			embed.addField(`Fastest Welcome`,`${rtstr} - ${getPlacementString(nextRstPos+1).replace('🔸', '') + ' place'}`, true)
+            if (nextRstPos != 0 && typeof nextRstPos != 'undefined') {
+                embed.addField(`Next Position (RT)`, `${rstPosStr} held by ${nextRstPosUser} with ${nextRstPosMs > 1000 ? (nextRstPosMs % 60000 / 1000).toFixed(rstDecimal)+'s' : nextRstPosMs+'ms'}\n${who.username} needs to improve by ${timeDifference > 1000 ? (timeDifference % 60000 / 1000).toFixed(rstDecimal)+'s' : timeDifference+'ms'} to take their place`, true)
+            }
 			message.reply(embed);
 		} else if (parseInt(args[0]) > 0) {
 			const pos = parseInt(args[0]);
@@ -314,29 +371,61 @@ client.on('message', async message => {
 			} else {
 				let whoisname = 'unknown [not in server]';
 				try {
-					const whois = await message.guild.members.fetch(sortedLB[pos-1][0]);
+					whois = await message.guild.members.fetch(sortedLB[pos-1][0]);
 					whoisname = whois.user.username;
 				} catch (err) {
 				}
-				let pointsstr = sortedLB[pos-1][1]+' points';
-
+				let pointsstr = `${getPointString(sortedLB[pos-1][1])}`;
 				let posstr = `${getPlacementString(pos)} place`;
+				let nextposstr = 'Not on the leaderboard';
+				let nextPosUser = 'unknown [not in server]';
+				let nextPos, nextPosPoints, pointsNeeded = 0;
+
+				// Determine who is one place above the requested user on the leaderboard
+				// and how many points are needed to take their place
+				nextPos = sortedLB.findIndex(entry => entry[0] == whois.id);
+				if (nextPos != 0 && typeof nextPos != 'undefined') {
+				    nextposstr = `${getPlacementString(nextPos).replace('🔸', '')} place`;
+				    nextPosId = await client.users.fetch(sortedLB[nextPos-1][0]);
+					nextPosUser = nextPosId.username;
+				    nextPosPoints = sortedLB[nextPos-1][1];
+				    pointsNeeded = nextPosPoints - guildPoints[whois.id] + 1;
+				}
 
 				let rtstr = 'No reaction time registered';
 				if (guildRT[sortedLB[pos-1][0]]) { 
-					rtstr = guildRT[sortedLB[pos-1][0]]+'ms'
+					rtstr = `${guildRT[sortedLB[pos-1][0]] > 1000 ? (guildRT[sortedLB[pos-1][0]] % 60000 / 1000).toFixed(rstDecimal)+'s' : guildRT[sortedLB[pos-1][0]]+'ms'}`;
+                	nextRstPos = sortedRT.findIndex(entry => entry[0] == whois.id);
+                	if (nextRstPos != 0 && typeof nextRstPos != 'undefined') {
+					    rstPosStr = `${getPlacementString(nextRstPos).replace('🔸', '')} place`;
+					    nextRstPosId = await client.users.fetch(sortedRT[nextRstPos-1][0]);
+						nextRstPosUser = nextRstPosId.username;
+					    nextRstPosMs = sortedRT[nextRstPos-1][1];
+					    timeDifference = guildRT[whois.id] - nextRstPosMs + 1;
+					}
 				}
 
 				embed.setDescription(`${whoisname}'s welcome points`)
-				embed.addField(pointsstr,posstr)
-				embed.addField(`Fastest Welcome`,rtstr)
-
+				embed.addField(pointsstr,posstr, true)
+				if (nextPos != 0 && typeof nextPos != 'undefined') {
+					embed.addField(`Next Position (WP)`, `${nextposstr} held by ${nextPosUser} with ${getPointString(nextPosPoints)}\n${whoisname} needs ${getPointString(pointsNeeded)} to take their place`, true)
+					embed.addField('\u200B', '\u200B')
+				}
+				embed.addField(`Fastest Welcome`, `${rtstr} - ${getPlacementString(nextRstPos+1).replace('🔸', '') + ' place'}`, true)
+                if (nextRstPos != 0 && typeof nextRstPos != 'undefined') {
+                    embed.addField(`Next Position (RT)`, `${rstPosStr} held by ${nextRstPosUser} with ${nextRstPosMs > 1000 ? (nextRstPosMs % 60000 / 1000).toFixed(rstDecimal)+'s' : nextRstPosMs+'ms'}\n${whoisname} needs to improve by ${timeDifference > 1000 ? (timeDifference % 60000 / 1000).toFixed(rstDecimal)+'s' : timeDifference+'ms'} to take their place`, true)
+                }
 				message.reply(embed);
 			}
 		}
 	} else if (command == 'help' || command == 'h'){
 		message.reply(sendHelp(whocalls, guildPrefix));
 	}
+	//if (!message.content.toLowerCase().startsWith('!clear')) { 
+	//	message.delete()
+	//	.then(() => console.log(`${whocalls.username}'s command message has been deleted`))
+	//	.catch(err => console.log(err));
+	//}
 });
 
 /* Welcome Points */
@@ -448,4 +537,9 @@ function getPlacementString(pos){
     	if (pos == 3) return `🟤 ${pos}rd`; 
     	else return `🔸${pos}rd`; }
     return `🔸${pos}th`;
+}
+
+// This deals with displaying singular/plural point values properly in the leaderboard content 
+function getPointString(pts) {
+	return `${pts} ${pts == 1 ? 'point' : 'points'}`; 
 }


### PR DESCRIPTION
- The commands `!wp me`, `!wp @User`, and `!wp POSITION` return details about the next leaderboard position for the requested user on both WP & RT leaderboards including:
    - The users occupying the next positions and their current WP & RT values. If the requested user is already in 1st place on either leaderboard, those details aren't shown.
    - The number of welcome points the requested user needs to take the next position in that leaderboard
    - How much faster their response time needs to be to take the next position in that leaderboard
- A few small QOL improvements including:
    - Singular point values are properly displayed as '1 point' instead of '1 points' on all leaderboard/next position details
    - Response times higher than 1000ms are displayed as seconds with 2 decimal places on all leaderboard/next position details